### PR TITLE
Touchstone authentication

### DIFF
--- a/common/templates/common/base.html
+++ b/common/templates/common/base.html
@@ -55,7 +55,7 @@
             <li><a class="dropdown-trigger" href="#!" data-target="dropdown1">GitHub</a></li>
             <li><a href="mailto:base12apps@gmail.com">Contact</a></li>
             {% if not request.user.is_authenticated %}
-            <li><a href="/login?next=">Login</a></li>
+            <li><a href="/login_touchstone?next=">Login</a></li>
             {% else %}
             {% if request.user.is_staff %}
             <li><a href="/analytics">Analytics</a></li>
@@ -89,7 +89,7 @@
       <li><a class="dropdown-trigger" href="#!" data-target="dropdown2">GitHub<i class="material-icons right">arrow_drop_down</i></a></li>
       <li><a href="mailto:base12apps@gmail.com">Contact</a></li>
       {% if not request.user.is_authenticated %}
-      <li><a href="/login?next=">Login</a></li>
+      <li><a href="/login_touchstone?next=">Login</a></li>
       {% else %}
       {% if request.user.is_staff %}
       <li><a href="/analytics">Analytics</a></li>

--- a/common/templates/common/base.html
+++ b/common/templates/common/base.html
@@ -55,7 +55,7 @@
             <li><a class="dropdown-trigger" href="#!" data-target="dropdown1">GitHub</a></li>
             <li><a href="mailto:base12apps@gmail.com">Contact</a></li>
             {% if not request.user.is_authenticated %}
-            <li><a href="/login_touchstone?next=">Login</a></li>
+            <li><a href="/login?next=%2F">Login</a></li>
             {% else %}
             {% if request.user.is_staff %}
             <li><a href="/analytics">Analytics</a></li>
@@ -89,7 +89,7 @@
       <li><a class="dropdown-trigger" href="#!" data-target="dropdown2">GitHub<i class="material-icons right">arrow_drop_down</i></a></li>
       <li><a href="mailto:base12apps@gmail.com">Contact</a></li>
       {% if not request.user.is_authenticated %}
-      <li><a href="/login_touchstone?next=">Login</a></li>
+      <li><a href="/login?next=%2F">Login</a></li>
       {% else %}
       {% if request.user.is_staff %}
       <li><a href="/analytics">Analytics</a></li>

--- a/common/templates/common/signup.html
+++ b/common/templates/common/signup.html
@@ -82,7 +82,7 @@
     </div>
     <div id="buttons">
       <br/>
-      <a class="submit" href="{% url 'login_touchstone' %}?sem={{ sem }}">Allow and Continue</a>
+      <a class="submit" href="/login?sem={{ sem }}">Allow and Continue</a>
       <br/><br/>
       <a class="cancel" href="{% url 'decline' %}">Not Now</a>
     </div>

--- a/common/templates/common/signup.html
+++ b/common/templates/common/signup.html
@@ -82,7 +82,7 @@
     </div>
     <div id="buttons">
       <br/>
-      <a class="submit" href="{% url 'login' %}?sem={{ sem }}">Allow and Continue</a>
+      <a class="submit" href="{% url 'login_touchstone' %}?sem={{ sem }}">Allow and Continue</a>
       <br/><br/>
       <a class="cancel" href="{% url 'decline' %}">Not Now</a>
     </div>

--- a/common/urls.py
+++ b/common/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url('new_user/', views.new_user, name='new_user'),
     url('signup/', views.signup, name='signup'),
     url('login/', views.login_oauth, name='login'),
+    url('login_touchstone/', views.login_touchstone, name='login_touchstone'),
     url('logout/', logout, {'next_page': 'index'}, name='logout'),
     url('set_semester/', views.set_semester, name='set_semester'),
     url('prefs/favorites/', views.favorites, name='favorites'),

--- a/common/views.py
+++ b/common/views.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 from catalog.models import Course, CourseFields
 from django.core.exceptions import ObjectDoesNotExist
-from fireroad.settings import RESTRICT_AUTH_REDIRECTS, MY_BASE_URL
+from django.conf import settings
 
 # One month for mobile, ~1 week for web
 TOKEN_EXPIRY_MOBILE = 2.6e6
@@ -26,8 +26,8 @@ def login_oauth(request):
         code = request.GET.get('code', None)
         redirect_URL = request.GET.get('redirect', None)
         if 'next' in request.GET:
-            redirect_URL = MY_BASE_URL + '/' + request.GET['next']
-        elif RESTRICT_AUTH_REDIRECTS and redirect_URL is not None and RedirectURL.objects.filter(url=redirect_URL).count() == 0:
+            redirect_URL = settings.MY_BASE_URL + '/' + request.GET['next']
+        elif settings.RESTRICT_AUTH_REDIRECTS and redirect_URL is not None and RedirectURL.objects.filter(url=redirect_URL).count() == 0:
             return HttpResponse("Redirect URL not registered", status=403)
         return redirect(oauth_code_url(request, after_redirect=redirect_URL))
 

--- a/common/views.py
+++ b/common/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from .models import *
@@ -128,6 +128,12 @@ def login_touchstone(request):
     if "redirect" in request.GET:
         # Redirect to the web application's page with a temporary code to get the access token
         return finish_login_redirect(access_info, request.GET["redirect"])
+    elif "next" in request.GET:
+        # Redirect to the given page in FireRoad
+        redirect_dest = request.GET.get("next", "")
+        if not redirect_dest:
+            redirect_dest = "index"
+        return redirect(reverse(redirect_dest))
     else:
         # Go to FireRoad's login success page, which is read by the mobile apps
         return render(request, 'common/login_success.html', {'access_info': json.dumps(access_info)})

--- a/common/views.py
+++ b/common/views.py
@@ -132,8 +132,8 @@ def login_touchstone(request):
         # Redirect to the given page in FireRoad
         redirect_dest = request.GET.get("next", "")
         if not redirect_dest:
-            redirect_dest = "index"
-        return redirect(reverse(redirect_dest))
+            redirect_dest = "/"
+        return redirect(redirect_dest)
     else:
         # Go to FireRoad's login success page, which is read by the mobile apps
         return render(request, 'common/login_success.html', {'access_info': json.dumps(access_info)})

--- a/common/views.py
+++ b/common/views.py
@@ -119,13 +119,15 @@ def login_touchstone(request):
     login(request, student.user)
 
     # Generate access token for the user
-    lifetime = TOKEN_EXPIRY_WEB if "redirect" in info else TOKEN_EXPIRY_MOBILE
+    lifetime = TOKEN_EXPIRY_WEB if "redirect" in request.GET else TOKEN_EXPIRY_MOBILE
     token = generate_token(request, student.user, lifetime)
-    access_info = {'success': True, 'username': student.user.username, 'current_semester': int(student.current_semester), 'academic_id': student.academic_id, 'access_token': token, 'sub': sub}
+    access_info = {'success': True, 'username': student.user.username, 'current_semester':
+                   int(student.current_semester), 'academic_id': student.academic_id,
+                   'access_token': token}
 
-    if "redirect" in info:
+    if "redirect" in request.GET:
         # Redirect to the web application's page with a temporary code to get the access token
-        return finish_login_redirect(access_info, info["redirect"])
+        return finish_login_redirect(access_info, request.GET["redirect"])
     else:
         # Go to FireRoad's login success page, which is read by the mobile apps
         return render(request, 'common/login_success.html', {'access_info': json.dumps(access_info)})

--- a/courseupdater/views.py
+++ b/courseupdater/views.py
@@ -8,7 +8,7 @@ from catalog.models import Course
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.admin.views.decorators import staff_member_required
 from django.forms.models import model_to_dict
-from fireroad.settings import BASE_DIR, CATALOG_BASE_DIR
+from django.conf import settings
 from requirements.diff import *
 import catalog_parse as cp
 
@@ -62,7 +62,7 @@ def compute_updated_files(version, base_dir):
 
 """Returns the numerical version for the given semester, e.g. "fall-2017"."""
 def current_version_for_semester(semester):
-    semester_dir = os.path.join(CATALOG_BASE_DIR, deltas_directory, semester_dir_prefix + semester)
+    semester_dir = os.path.join(settings.CATALOG_BASE_DIR, deltas_directory, semester_dir_prefix + semester)
     max_version = 0
     for path in os.listdir(semester_dir):
         if path.find(delta_file_prefix) == 0:
@@ -75,7 +75,7 @@ def current_version_for_semester(semester):
 def compute_semester_delta(semester_comps, version_num, req_version_num=-1):
     # Walk through the delta files
     semester_dir = semester_dir_prefix + semester_comps[0] + '-' + semester_comps[1]
-    updated_files, updated_version = compute_updated_files(version_num, os.path.join(CATALOG_BASE_DIR, deltas_directory, semester_dir))
+    updated_files, updated_version = compute_updated_files(version_num, os.path.join(settings.CATALOG_BASE_DIR, deltas_directory, semester_dir))
 
     # Write out the updated files to JSON
     def url_comp(x):
@@ -87,7 +87,8 @@ def compute_semester_delta(semester_comps, version_num, req_version_num=-1):
 
     # Check requirements also, if necessary
     if req_version_num != -1:
-        updated_files, updated_version = compute_updated_files(req_version_num, os.path.join(CATALOG_BASE_DIR, deltas_directory, requirements_dir))
+        updated_files, updated_version = compute_updated_files(req_version_num,
+                                                               os.path.join(settings.CATALOG_BASE_DIR, deltas_directory, requirements_dir))
         urls_to_update = list(map(lambda x: requirements_dir + '/' + x + '.reql', sorted(list(updated_files))))
         resp['rv'] = updated_version
         resp['r_delta'] = urls_to_update
@@ -95,7 +96,7 @@ def compute_semester_delta(semester_comps, version_num, req_version_num=-1):
 
 def list_semesters():
     sems = []
-    for path in os.listdir(os.path.join(CATALOG_BASE_DIR, deltas_directory)):
+    for path in os.listdir(os.path.join(settings.CATALOG_BASE_DIR, deltas_directory)):
         if path.find(semester_dir_prefix) == 0:
             sems.append(path[len(semester_dir_prefix):])
     def semester_sort_key(x):
@@ -177,7 +178,7 @@ def update_catalog(request):
         else:
             form = CatalogUpdateDeployForm()
 
-        diff_path = os.path.join(CATALOG_BASE_DIR, "diff.txt")
+        diff_path = os.path.join(settings.CATALOG_BASE_DIR, "diff.txt")
         if os.path.exists(diff_path):
             with open(diff_path, 'r') as file:
                 diffs = [line for line in file.readlines() if len(line)]

--- a/fireroad/settings.py
+++ b/fireroad/settings.py
@@ -12,6 +12,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 CATALOG_BASE_DIR = ""
 
+# Use the Django default login page for local debugging
+LOGIN_URL = "/admin/login"
+
 # Security settings
 
 # If True, login redirects will be required to be registered as a RedirectURL

--- a/fireroad/settings.py
+++ b/fireroad/settings.py
@@ -16,7 +16,7 @@ CATALOG_BASE_DIR = ""
 
 # If True, login redirects will be required to be registered as a RedirectURL
 # Set to True in production!
-RESTRICT_AUTH_REDIRECTS = True
+RESTRICT_AUTH_REDIRECTS = False
 
 with open(os.path.join(os.path.dirname(__file__), 'secret.txt')) as f:
     SECRET_KEY = f.read().strip()
@@ -146,7 +146,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
-STATIC_URL = '/fireroad/static/'
+STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 

--- a/fireroad/settings_dev.py
+++ b/fireroad/settings_dev.py
@@ -8,6 +8,9 @@ from .settings import *
 # Location of catalog files on the server
 CATALOG_BASE_DIR = "/var/www/html/catalogs"
 
+# URL used to log in
+LOGIN_URL = "/login_touchstone"
+
 # Security settings more relaxed on dev server
 RESTRICT_AUTH_REDIRECTS = False
 DEBUG = True

--- a/fireroad/settings_prod.py
+++ b/fireroad/settings_prod.py
@@ -8,6 +8,9 @@ from .settings import *
 # Location of catalog files on the server
 CATALOG_BASE_DIR = "/var/www/html/catalogs"
 
+# URL used to log in (e.g. to admin)
+LOGIN_URL = "/login_touchstone"
+
 # Security settings
 RESTRICT_AUTH_REDIRECTS = True
 DEBUG = False

--- a/fireroad/urls.py
+++ b/fireroad/urls.py
@@ -15,11 +15,12 @@ Including another URLconf
 """
 from django.conf.urls import url, include
 from django.contrib.admin.views.decorators import staff_member_required
+from django.views.generic.base import RedirectView
 from django.contrib import admin
 from django.conf import settings
 
-admin.autodiscover()
-admin.site.login = staff_member_required(admin.site.login, login_url=settings.LOGIN_URL)
+# admin.autodiscover()
+# admin.site.login = staff_member_required(admin.site.login, login_url=settings.LOGIN_URL)
 
 urlpatterns = [
     url(r'courses/', include('catalog.urls')),
@@ -31,3 +32,16 @@ urlpatterns = [
     url(r'requirements/', include('requirements.urls')),
     url(r'', include('common.urls')),
 ]
+
+# Redirect to the appropriate login page if one is specified in the settings module
+if settings.LOGIN_URL:
+    if settings.LOGIN_URL.strip("/") != 'admin/login':
+        urlpatterns.insert(0, url(r'^admin/login/$', RedirectView.as_view(url=settings.LOGIN_URL,
+                                                                          permanent=True,
+                                                                          query_string=True)))
+    if settings.LOGIN_URL.strip("/") != 'login':
+        urlpatterns.insert(0, url(r'^login/$', RedirectView.as_view(url=settings.LOGIN_URL,
+                                                                    permanent=True,
+                                                                    query_string=True)))
+
+

--- a/fireroad/urls.py
+++ b/fireroad/urls.py
@@ -13,8 +13,13 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
 from django.conf.urls import url, include
+from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib import admin
+from django.conf import settings
+
+admin.autodiscover()
+admin.site.login = staff_member_required(admin.site.login, login_url=settings.LOGIN_URL)
 
 urlpatterns = [
     url(r'courses/', include('catalog.urls')),

--- a/recommender.py
+++ b/recommender.py
@@ -13,7 +13,6 @@ import time
 import csv
 import re
 import random
-os.environ['DJANGO_SETTINGS_MODULE'] = "fireroad.settings"
 django.setup()
 from recommend.models import Rating, Recommendation, DEFAULT_RECOMMENDATION_TYPE
 from sync.models import Road

--- a/update_db.py
+++ b/update_db.py
@@ -3,7 +3,6 @@ import re
 import django
 import sys
 
-os.environ['DJANGO_SETTINGS_MODULE'] = "fireroad.settings"
 django.setup()
 
 from courseupdater.views import *
@@ -13,7 +12,6 @@ from requirements.models import *
 from catalog.models import *
 from django.db import DatabaseError, transaction
 from django import db
-from fireroad.settings import CATALOG_BASE_DIR
 from common.models import *
 from common.oauth_client import LOGIN_TIMEOUT
 from django.utils.dateparse import parse_datetime
@@ -40,11 +38,11 @@ def deploy_catalog_updates():
     """Deploys any staged catalog update if one exists."""
     for update in CatalogUpdate.objects.filter(is_staged=True, is_completed=False):
         # Commit this update
-        new_path = os.path.join(CATALOG_BASE_DIR, 'sem-' + update.semester + '-new')
-        old_path = os.path.join(CATALOG_BASE_DIR, 'sem-' + update.semester)
+        new_path = os.path.join(settings.CATALOG_BASE_DIR, 'sem-' + update.semester + '-new')
+        old_path = os.path.join(settings.CATALOG_BASE_DIR, 'sem-' + update.semester)
 
         delta = cp.make_delta(new_path, old_path)
-        cp.commit_delta(new_path, old_path, os.path.join(CATALOG_BASE_DIR, deltas_directory), delta)
+        cp.commit_delta(new_path, old_path, os.path.join(settings.CATALOG_BASE_DIR, deltas_directory), delta)
 
         update.is_completed = True
         update.save()
@@ -102,9 +100,9 @@ def update_catalog():
             # Save this for last
             related_path = path
         else:
-            update_catalog_with_file(os.path.join(CATALOG_BASE_DIR, path), semester)
+            update_catalog_with_file(os.path.join(settings.CATALOG_BASE_DIR, path), semester)
     if related_path is not None:
-        parse_related_file(os.path.join(CATALOG_BASE_DIR, related_path))
+        parse_related_file(os.path.join(settings.CATALOG_BASE_DIR, related_path))
 
 ### REQUIREMENTS UPDATE
 
@@ -143,7 +141,7 @@ def perform_deployments():
                     print("Edit request {} has no contents, skipping".format(edit_req))
                     continue
 
-                with open(os.path.join(CATALOG_BASE_DIR, requirements_dir, edit_req.list_id + ".reql"), 'w') as file:
+                with open(os.path.join(settings.CATALOG_BASE_DIR, requirements_dir, edit_req.list_id + ".reql"), 'w') as file:
                     file.write(edit_req.contents.encode('utf-8'))
 
                 edit_req.committed = False
@@ -157,7 +155,7 @@ def perform_deployments():
 
     # Write delta file
     if len(delta) > 0:
-        write_delta_file(sorted(delta), os.path.join(CATALOG_BASE_DIR, "deltas", requirements_dir))
+        write_delta_file(sorted(delta), os.path.join(settings.CATALOG_BASE_DIR, "deltas", requirements_dir))
 
 
 def update_requirements():
@@ -169,7 +167,7 @@ def update_requirements():
     for path_name in req_urls[REQUIREMENTS_INFO_KEY]:
         print(path_name)
         new_req = RequirementsList.objects.create(list_id=os.path.basename(path_name))
-        with open(os.path.join(CATALOG_BASE_DIR, path_name), 'rb') as file:
+        with open(os.path.join(settings.CATALOG_BASE_DIR, path_name), 'rb') as file:
             new_req.parse(file.read().decode('utf-8'))
         new_req.save()
 


### PR DESCRIPTION
Allows redirects for login on localhost, dev, and prod to be different through the use of the `LOGIN_URL` variable defined in `settings.py`, `settings_dev.py`, and `settings_prod.py`. Now dev and prod will both redirect to the `/login_touchstone` endpoint, which is configured to run Touchstone auth. This is visible on fireroad-dev.mit.edu right now. Clients shouldn't need to change anything, so everyone gets Touchstone authentication for free.