### PR TITLE
Support for progress assertions

### DIFF
--- a/common/static/common/css/shared.css
+++ b/common/static/common/css/shared.css
@@ -17,3 +17,24 @@
 a {
   color: rgb(224, 20, 20);
 }
+
+.file-example-content {
+  overflow-y: scroll;
+  max-height: 240px;
+}
+
+pre.code {
+  margin: 0 !important;
+}
+
+.json-key {
+  color: #1976D2 !important;
+}
+
+.json-string-value {
+  color: #e91e63 !important;
+}
+
+.json-number-value {
+  color: #4CAF50 !important;
+}

--- a/common/templates/common/docs/file_formats.html
+++ b/common/templates/common/docs/file_formats.html
@@ -40,11 +40,12 @@
 
 <h5 class="code">progressAssertions</h5>
 
-<p>A dictionary mapping requirement IDs to progress assertion dictionaries. Requirement IDs are defined as in <span class="code">progressOverrides</span>, while progress assertion values are dictionaries that can contain the given keys:</p>
+<p>A dictionary mapping requirement IDs to progress assertion dictionaries. Requirement IDs are defined as in <span class="code">progressOverrides</span>, while progress assertion values are dictionaries that can contain the given keys, in decreasing order of precedence:</p>
 
 <ul class="collection">
-  <li class="collection-item"><span class="code">substitutions</span> - A list of subject ID strings. If this key is present, the user is overriding the given requirement by completing this list of courses instead of the published list. This list may be empty, which corresponds to an automatic fulfillment of the requirement.</li>
+  <li class="collection-item"><span class="code">override</span> - An integer that specifies an absolute override to the progress of this requirement (equivalent to the old <span class="code">progressOverrides</span> values). This value is in units of subjects or units depending on the threshold criterion of the requirement. <em>The override value will be ignored if the requirement is not a plain-string requirement, or if the requirement does not have an explicitly specified threshold.</em></li>
   <li class="collection-item"><span class="code">ignore</span> - A boolean indicating whether to ignore this requirement. If this is <span class="code">true</span>, then the fulfillment status of this requirement should be ignored when computing parent fulfillment statuses.</li>
+  <li class="collection-item"><span class="code">substitutions</span> - A list of subject ID strings. If this key is present, the user is overriding the given requirement by completing this list of courses instead of the published list. This list may be empty, which corresponds to an automatic fulfillment of the requirement.</li>
 </ul>
 
 <h5>Example</h5>

--- a/common/templates/common/docs/file_formats.html
+++ b/common/templates/common/docs/file_formats.html
@@ -1,0 +1,186 @@
+{% extends "common/docs/base.html" %}
+
+{% block nav %}
+{% include "common/docs/sidebar.html" with active_id="file_formats" %}
+{% endblock %}
+
+{% block content %}
+<h2 class="red-text text-darken-4">File Formats</h2>
+
+<h4 class="red-text text-darken-4">Road File</h4>
+
+<p>The FireRoad road file (<span class="code">.road</span> file extension) uses a JSON format to specify a user's majors and minors, selected courses, and progress assertions (also known as substitutions or overrides). Each file is a JSON object containing the following keys:</p>
+
+<h5 class="code">coursesOfStudy</h5>
+
+<p>A list of majors and minors that the user has added (e.g. <span class="code">major6</span>, <span class="code">girs</span>). Each course of study corresponds in name to a requirements list.</p>
+
+<h5 class="code">selectedSubjects</h5>
+
+<p>A list of selected subjects, specifying basic information about the subject and when it appears in the road. Each subject is a JSON object with the following keys:</p>
+
+<ul class="collection">
+  <li class="collection-item"><span class="code">subject_id</span> - the subject ID (e.g. "6.009")</li>
+  <li class="collection-item"><span class="code">title</span> - the subject title (e.g. "Fundamentals of Programming")</li>
+  <li class="collection-item"><span class="code">units</span> - the total number of units provided by this subject</li>
+  <li class="collection-item"><span class="code">semester</span> - the semester number in which this subject is placed. The semester numbers are zero-indexed, with the order as follows: <em>Previous Credit, Freshman Fall, Freshman IAP, Freshman Spring, ... , Senior Spring</em></li>
+  <li class="collection-item"><span class="code">overrideWarnings</span> - A boolean indicating whether the prereq/coreq and not-offered warnings should be hidden for this subject.</li>
+</ul>
+
+<strong>Notes:</strong>
+<ol>
+  <li>The information contained in each subject is intentionally redundant so that the road file can be displayed in a preliminary way without loading the entire course database.</li>
+  <li>The same subject ID may appear multiple times with different semester numbers, if the user selects the same subject for different semesters.</li>
+  <li>Subjects in the selected subjects list may be <strong>generic courses</strong>, which are defined in <a href="https://github.com/venkatesh-sivaraman/FireRoad/blob/master/FireRoad/Course.swift" target="_blank">the native apps' Course model</a>.
+</ol>
+
+<h5 class="code">progressOverrides</h5>
+
+<p><strong class="red-text text-darken-4">Deprecated - prefer <span class="code">progressAssertions</span> instead.</strong> A dictionary mapping requirement IDs to manual progress values. Requirement IDs are '.'-delimited strings that identify a particular requirements statement. For example, <span class="code">major3a.2</span> specifies the 3rd child of the 3-A major, which is a manual progress requirement defined as <span class="code">""72 units""{&gt;=72u}</span>. Manual progress values are integers specifying how far the user is toward fulfilling that requirement; the range is determined by the requirements statement. In the previous example, the value may range from 0 to 72.</p>
+
+<h5 class="code">progressAssertions</h5>
+
+<p>A dictionary mapping requirement IDs to progress assertion dictionaries. Requirement IDs are defined as in <span class="code">progressOverrides</span>, while progress assertion values are dictionaries that can contain the given keys:</p>
+
+<ul class="collection">
+  <li class="collection-item"><span class="code">substitutions</span> - A list of subject ID strings. If this key is present, the user is overriding the given requirement by completing this list of courses instead of the published list. This list may be empty, which corresponds to an automatic fulfillment of the requirement.</li>
+  <li class="collection-item"><span class="code">ignore</span> - A boolean indicating whether to ignore this requirement. If this is <span class="code">true</span>, then the fulfillment status of this requirement should be ignored when computing parent fulfillment statuses.</li>
+</ul>
+
+<h5>Example</h5>
+
+<p>Below is an example of a road file illustrating the use of progress assertions:</p>
+
+<div class="card hoverable">
+  <div class="card-content file-example-content">
+    <pre class="code">{
+  <span class="json-key">"coursesOfStudy"</span> : [
+    <span class="json-string-value">"girs"</span>,
+    <span class="json-string-value">"major6-7"</span>
+  ],
+  <span class="json-key">"progressAssertions"</span> : {
+    <span class="grey-text">// Fulfill independent inquiry with 21M.387</span>
+    <span class="json-key">"major6-2.1.1"</span> : {
+      <span class="json-key">"substitutions"</span> : [<span class="json-string-value">"21M.387"</span>]
+    },
+    <span class="grey-text">// Ignore 6.047 in lab subjects</span>
+    <span class="json-key">"major6-2.1.0.2"</span>: {
+      <span class="json-key">"ignore"</span>: <span class="json-number-value">true</span>
+    }
+  },
+  <span class="json-key">"selectedSubjects"</span> : [
+    {
+      <span class="json-key">"overrideWarnings"</span> : <span class="json-number-value">false</span>,
+      <span class="json-key">"semester"</span> : <span class="json-number-value">0</span>,
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Generic Physics I GIR"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"PHY1"</span>,
+      <span class="json-key">"units"</span> : <span class="json-number-value">12</span>
+    },
+    {
+      <span class="json-key">"overrideWarnings"</span> : <span class="json-number-value">false</span>,
+      <span class="json-key">"semester"</span> : <span class="json-number-value">1</span>,
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Principles of Chemical Science"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"5.112"</span>,
+      <span class="json-key">"units"</span> : <span class="json-number-value">12</span>
+    },
+    {
+      <span class="json-key">"overrideWarnings"</span> : <span class="json-number-value">false</span>,
+      <span class="json-key">"semester"</span> : <span class="json-number-value">4</span>,
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Fundamentals of Programming"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"6.009"</span>,
+      <span class="json-key">"units"</span> : <span class="json-number-value">12</span>
+    },
+    {
+      <span class="json-key">"overrideWarnings"</span> : <span class="json-number-value">false</span>,
+      <span class="json-key">"semester"</span> : <span class="json-number-value">4</span>,
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Advanced Music Performance"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"21M.480"</span>,
+      <span class="json-key">"units"</span> : <span class="json-number-value">6</span>
+    },
+    {
+      <span class="json-key">"overrideWarnings"</span> : <span class="json-number-value">false</span>,
+      <span class="json-key">"semester"</span> : <span class="json-number-value">6</span>,
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Advanced Music Performance"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"21M.480"</span>,
+      <span class="json-key">"units"</span> : <span class="json-number-value">6</span>
+    }
+  ]
+}</pre>
+  </div>
+</div>
+
+<h4 class="red-text text-darken-4">Schedule File</h4>
+
+<p>The FireRoad schedule file (<span class="code">.sched</span> file extension) uses a JSON format to specify a user's selected subjects and sections (e.g. for recitations). Each file is a JSON object containing only one key at the moment:</p>
+
+<h5 class="code">selectedSubjects</h5>
+
+<p>A list of selected subjects, specifying basic information about the subject and its selected sections. Each subject is a JSON object with the following keys:</p>
+
+<ul class="collection">
+  <li class="collection-item"><span class="code">subject_id</span> - the subject ID (e.g. "6.009")</li>
+  <li class="collection-item"><span class="code">title</span> - the subject title (e.g. "Fundamentals of Programming")</li>
+  <li class="collection-item"><span class="code">allowedSections</span> - a dictionary of allowed schedule units, where the keys are the section type (e.g. "lecture", "recitation", "lab", "design"), and the values are lists of schedule unit numbers. This indicates the user-defined constraints on which schedule units can be selected. See below for information about the schedule units.</li>
+  <li class="collection-item"><span class="code">selectedSections</span> - a dictionary of selected schedule units, where the keys are the section type, and the values are single schedule unit numbers. See below for more about the schedule units.</li>
+</ul>
+
+<p><strong>Schedule units.</strong> The schedule unit is an internal model type in the FireRoad app, which represents the most granular weekly-repeating unit that a user can select in their schedule. For example, a user can select an 18.03 lecture that takes place MWF at 1pm; this would be represented by a single schedule unit.</p>
+
+<p>The course database defines the schedule units for each subject, which is then internally represented as a dictionary of section types (lecture, recitation, etc.) pointing to lists of schedule units as displayed on the registrar site. Rather than specify the exact times within the document, the schedule JSON file specifies the <em>index</em> of the schedule unit that has been selected/constrained. This allows the document to be robust to changes in the exact times of each section. (If the schedule units list becomes shorter than the index specified, the FireRoad app by default reverts to the first-generated schedule option.)</p>
+
+<h5>Example</h5>
+
+<p>Below is an example of a schedule file illustrating the use of schedule unit constraints:</p>
+
+<div class="card hoverable">
+  <div class="card-content file-example-content">
+    <pre class="code">{
+  <span class="json-key">"selectedSubjects"</span> : [
+    {
+      <span class="json-key">"selectedSections"</span> : {
+        <span class="json-key">"Recitation"</span> : <span class="json-number-value">8</span>,
+        <span class="json-key">"Lecture"</span> : <span class="json-number-value">0</span>
+      },
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Differential Equations"</span>,
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"18.03"</span>,
+      <span class="json-key">"allowedSections"</span> : {
+        <span class="json-key">"Recitation"</span> : [
+          <span class="json-number-value">0</span>,
+          <span class="json-number-value">3</span>,
+          <span class="json-number-value">4</span>,
+          <span class="json-number-value">7</span>,
+          <span class="json-number-value">8</span>,
+          <span class="json-number-value">9</span>
+        ]
+      }
+    },
+    {
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"6.031"</span>,
+      <span class="json-key">"selectedSections"</span> : {
+        <span class="json-key">"Lecture"</span> : <span class="json-number-value">0</span>
+      },
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Elements of Software Construction"</span>
+    },
+    {
+      <span class="json-key">"subject_id"</span> : <span class="json-string-value">"21G.501"</span>,
+      <span class="json-key">"selectedSections"</span> : {
+        <span class="json-key">"Lecture"</span> : <span class="json-number-value">1</span>
+      },
+      <span class="json-key">"title"</span> : <span class="json-string-value">"Japanese I"</span>
+    }
+  ]
+}</pre>
+  </div>
+</div>
+
+<h4 class="red-text text-darken-4">Requirements List File</h4>
+
+<p>For information about the requirements list file syntax (<span class="code">.reql</span> file extension), see the <a href="/requirements">Requirements Editor</a>.</p>
+
+<div id="sequential-nav">
+  <div class="col s6">
+    <a href="/reference/recommender" class="red-text text-darken-1"><i class="material-icons">chevron_left</i> Recommender</a>
+  </div>
+  <br/><br/>
+</div>
+{% endblock %}

--- a/common/templates/common/docs/recommender.html
+++ b/common/templates/common/docs/recommender.html
@@ -18,6 +18,11 @@
   <div class="col s6">
     <a href="/reference/sync" class="red-text text-darken-1"><i class="material-icons">chevron_left</i> Sync</a>
   </div>
+  <div class="col s6">
+    <div class="right-align">
+      <a href="/reference/file_formats" class="red-text text-darken-1">File Formats <i class="material-icons">chevron_right</i></a>
+    </div>
+  </div>
   <br/><br/>
 </div>
 {% endblock %}

--- a/common/templates/common/docs/requirements.html
+++ b/common/templates/common/docs/requirements.html
@@ -53,6 +53,8 @@
   <li class="collection-item"><span class="code">max</span> - the maximum possible progress, serving as a denominator for <span class="code">progress</span></li>
   <li class="collection-item"><span class="code">percent_fulfilled</span> - the percentage fulfilled</li>
   <li class="collection-item"><span class="code">sat_courses</span> - a list of courses that satisfies this requirement</li>
+  <li class="collection-item"><span class="code">is_bypassed</span> - if present, a boolean indicating whether this requirement has been bypassed because of a progress assertion on one of its ancestors in the tree</li>
+  <li class="collection-item"><span class="code">assertion</span> - if present, a JSON object representing a progress assertion that was made on this requirement by the input road file. The format is the same as the progress assertion object defined in the <a href="/reference/file_formats">road file spec</a>.</li>
 </ul>
 
 <div id="sequential-nav">

--- a/common/templates/common/docs/sidebar.html
+++ b/common/templates/common/docs/sidebar.html
@@ -23,7 +23,9 @@
                 <li class="{% if active_id == "recommender" %}active{% endif %}">
                   <a href="/reference/recommender">Recommender</a>
                 </li>
-
+                <li class="{% if active_id == "file_formats" %}active{% endif %}">
+                  <a href="/reference/file_formats">File Formats</a>
+                </li>
             </ul>
      </div>
 </div>

--- a/common/urls.py
+++ b/common/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     url('reference/requirements', TemplateView.as_view(template_name='common/docs/requirements.html'), name='requirements'),
     url('reference/sync', TemplateView.as_view(template_name='common/docs/sync.html'), name='sync'),
     url('reference/recommender', TemplateView.as_view(template_name='common/docs/recommender.html'), name='recommender'),
+    url('reference/file_formats', TemplateView.as_view(template_name='common/docs/file_formats.html'), name='file_formats'),
 
     # index
     url(r'^$', TemplateView.as_view(template_name='common/index.html'), name='index'),

--- a/requirements/progress.py
+++ b/requirements/progress.py
@@ -95,6 +95,10 @@ class JSONProgressConstants:
     percent_fulfilled = "percent_fulfilled"
     satisfied_courses = "sat_courses"
 
+    # Progress assertions
+    is_bypassed = "is_bypassed"
+    override = "override"
+
 
 class Progress(object):
     """An object describing simple progress towards a requirement
@@ -174,16 +178,106 @@ class RequirementsProgress(object):
 
         return [], []
 
-    def compute(self, courses, progress_overrides):
+    def compute_assertions(self, courses, progress_assertions):
+        """
+        Computes the fulfillment of this requirement based on progress assertions, and returns
+        True if the requirement has an assertion available or False otherwise.
+
+        Assertions are in the format of a dictionary keyed by requirements list paths, where the
+        values are dictionaries containing two possible keys: "substitutions", which should be a
+        list of course IDs that combine to substitute for the requirement, and "ignore", which
+        indicates that the requirement is not to be used when satisfying later requirements. The
+        ignore flag takes precedence over substitutions, but for clarity it is preferred that only
+        one or the other is provided.
+        """
+        self.override = progress_assertions.get(self.list_path, None)
+        self.is_bypassed = False
+        if self.override is not None:
+            substitutions = self.override.get("substitutions", None) #List of substitutions
+            ignore = self.override.get("ignore", False)               #Boolean
+        else:
+            substitutions = None
+            ignore = False
+
+        if ignore:
+            self.is_fulfilled = False
+            subject_progress = Progress(0, 0)
+            self.subject_fulfillment = subject_progress
+            self.subject_progress = subject_progress.progress
+            self.subject_max = subject_progress.max
+            unit_progress = Progress(0, 0)
+            self.unit_fulfillment = unit_progress
+            self.unit_progress = unit_progress.progress
+            self.unit_max = unit_progress.max
+            progress = Progress(0, 0)
+            self.progress = progress.progress
+            self.progress_max = progress.max
+            self.percent_fulfilled = progress.get_percent()
+            self.fraction_fulfilled = progress.get_fraction()
+            self.satisfied_courses = []
+            return True
+        if substitutions is not None:
+            satisfied_courses = set()
+            subs_satisfied = 0
+            for sub in substitutions:
+                for course in courses:
+                    if course.satisfies(sub, courses):
+                        subs_satisfied += 1
+                        satisfied_courses.add(course)
+                        break
+            subject_progress = Progress(subs_satisfied, len(substitutions))
+            self.is_fulfilled = subs_satisfied == len(substitutions)
+            self.subject_fulfillment = subject_progress
+            self.subject_progress = subject_progress.progress
+            self.subject_max = subject_progress.max
+            unit_progress = Progress(subs_satisfied * DEFAULT_UNIT_COUNT, len(substitutions) * DEFAULT_UNIT_COUNT)
+            self.unit_fulfillment = unit_progress
+            self.unit_progress = unit_progress.progress
+            self.unit_max = unit_progress.max
+            progress = subject_progress
+            self.progress = progress.progress
+            self.progress_max = progress.max
+            self.percent_fulfilled = progress.get_percent()
+            self.fraction_fulfilled = progress.get_fraction()
+            self.satisfied_courses = list(satisfied_courses)
+            return True
+
+        return False
+
+    def bypass_children(self):
+        """Sets the is_bypassed flag of the recursive children of this progress object to True."""
+        for child in self.children:
+            child.is_bypassed = True
+            child.is_fulfilled = False
+            child.subject_fulfillment = Progress(0, 0)
+            child.subject_progress = 0
+            child.subject_max = 0
+            child.unit_fulfillment = Progress(0, 0)
+            child.unit_progress = 0
+            child.unit_max = 0
+            child.progress = 0
+            child.progress_max = 0
+            child.percent_fulfilled = 0
+            child.fraction_fulfilled = 0
+            child.satisfied_courses = []
+            child.override = None
+            child.bypass_children()
+
+    def compute(self, courses, progress_overrides, progress_assertions):
         """Computes and stores the status of the requirements statement using the
         given list of Course objects."""
         # Compute status of children and then self, adapted from mobile apps' computeRequirementsStatus method
         satisfied_courses = set()
+        if self.compute_assertions(courses, progress_assertions):
+            self.bypass_children()
+            return
 
         if self.list_path in progress_overrides:
             manual_progress = progress_overrides[self.list_path]
         else:
             manual_progress = 0
+        self.is_bypassed = False
+        self.override = None
 
         if self.statement.requirement is not None:
             #it is a basic requirement
@@ -241,7 +335,7 @@ class RequirementsProgress(object):
             num_courses_satisfied = 0
 
             for req_progress in self.children:
-                req_progress.compute(courses, progress_overrides)
+                req_progress.compute(courses, progress_overrides, progress_assertions)
                 req_satisfied_courses = req_progress.satisfied_courses
 
                 if req_progress.is_fulfilled and len(req_progress.satisfied_courses) > 0:
@@ -352,6 +446,11 @@ class RequirementsProgress(object):
         stmt_json[JSONProgressConstants.progress_max] = self.progress_max
         stmt_json[JSONProgressConstants.percent_fulfilled] = self.percent_fulfilled
         stmt_json[JSONProgressConstants.satisfied_courses] = map(lambda c: c.subject_id, self.satisfied_courses)
+
+        if self.is_bypassed:
+            stmt_json[JSONProgressConstants.is_bypassed] = self.is_bypassed
+        if self.override:
+            stmt_json[JSONProgressConstants.override] = self.override
 
         if full:
             if self.children:

--- a/requirements/progress.py
+++ b/requirements/progress.py
@@ -97,7 +97,7 @@ class JSONProgressConstants:
 
     # Progress assertions
     is_bypassed = "is_bypassed"
-    override = "override"
+    assertion = "assertion"
 
 
 class Progress(object):
@@ -190,11 +190,11 @@ class RequirementsProgress(object):
         ignore flag takes precedence over substitutions, but for clarity it is preferred that only
         one or the other is provided.
         """
-        self.override = progress_assertions.get(self.list_path, None)
+        self.assertion = progress_assertions.get(self.list_path, None)
         self.is_bypassed = False
-        if self.override is not None:
-            substitutions = self.override.get("substitutions", None) #List of substitutions
-            ignore = self.override.get("ignore", False)               #Boolean
+        if self.assertion is not None:
+            substitutions = self.assertion.get("substitutions", None) #List of substitutions
+            ignore = self.assertion.get("ignore", False)               #Boolean
         else:
             substitutions = None
             ignore = False
@@ -260,7 +260,7 @@ class RequirementsProgress(object):
             child.percent_fulfilled = 0
             child.fraction_fulfilled = 0
             child.satisfied_courses = []
-            child.override = None
+            child.assertion = None
             child.bypass_children()
 
     def compute(self, courses, progress_overrides, progress_assertions):
@@ -277,7 +277,7 @@ class RequirementsProgress(object):
         else:
             manual_progress = 0
         self.is_bypassed = False
-        self.override = None
+        self.assertion = None
 
         if self.statement.requirement is not None:
             #it is a basic requirement
@@ -449,8 +449,8 @@ class RequirementsProgress(object):
 
         if self.is_bypassed:
             stmt_json[JSONProgressConstants.is_bypassed] = self.is_bypassed
-        if self.override:
-            stmt_json[JSONProgressConstants.override] = self.override
+        if self.assertion:
+            stmt_json[JSONProgressConstants.assertion] = self.assertion
 
         if full:
             if self.children:

--- a/requirements/progress.py
+++ b/requirements/progress.py
@@ -219,22 +219,32 @@ class RequirementsProgress(object):
         if substitutions is not None:
             satisfied_courses = set()
             subs_satisfied = 0
+            units_satisfied = 0
             for sub in substitutions:
                 for course in courses:
                     if course.satisfies(sub, courses):
                         subs_satisfied += 1
+                        units_satisfied += course.total_units
                         satisfied_courses.add(course)
                         break
-            subject_progress = Progress(subs_satisfied, len(substitutions))
-            self.is_fulfilled = subs_satisfied == len(substitutions)
+            if self.statement.is_plain_string and self.threshold is not None:
+                subject_progress = Progress(subs_satisfied,
+                                            self.threshold.cutoff_for_criterion(CRITERION_SUBJECTS))
+                unit_progress = Progress(units_satisfied,
+                                         self.threshold.cutoff_for_criterion(CRITERION_UNITS))
+                progress = subject_progress if self.threshold.criterion == CRITERION_SUBJECTS else unit_progress
+                self.is_fulfilled = progress.progress == progress.max
+            else:
+                subject_progress = Progress(subs_satisfied, len(substitutions))
+                self.is_fulfilled = subs_satisfied == len(substitutions)
+                unit_progress = Progress(subs_satisfied * DEFAULT_UNIT_COUNT, len(substitutions) * DEFAULT_UNIT_COUNT)
+                progress = subject_progress
             self.subject_fulfillment = subject_progress
             self.subject_progress = subject_progress.progress
             self.subject_max = subject_progress.max
-            unit_progress = Progress(subs_satisfied * DEFAULT_UNIT_COUNT, len(substitutions) * DEFAULT_UNIT_COUNT)
             self.unit_fulfillment = unit_progress
             self.unit_progress = unit_progress.progress
             self.unit_max = unit_progress.max
-            progress = subject_progress
             self.progress = progress.progress
             self.progress_max = progress.max
             self.percent_fulfilled = progress.get_percent()


### PR DESCRIPTION
Adds the ability to pass in progress assertions to the requirements status computation, allowing for substitutions of specific sets of courses as well as the ability to explicitly disable a requirement from counting. This solves both the "petitions" problem as well as the double-counting problem, though the user is currently expected to input the constraint by disabling the requirement that would double-count.

The requirements status function is backwards-compatible and still allows support for the old `progressOverrides` key, but the new `progressAssertions` key is used first when available.