### PR TITLE
Virtual status

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -103,6 +103,7 @@ class CourseFields:
     quarter_information = "quarter_information"
     related_subjects = "related_subjects"
     schedule = "schedule"
+    virtual_status = "virtual_status"
     url = "url"
     rating = "rating"
     in_class_hours = "in_class_hours"
@@ -169,6 +170,7 @@ CSV_HEADERS = {
     CourseAttribute.notOfferedYear:             (CourseFields.not_offered_year, string_converter),
     CourseAttribute.quarterInformation:         (CourseFields.quarter_information, string_converter),
     CourseAttribute.schedule:                   (CourseFields.schedule, string_converter),
+    CourseAttribute.virtualStatus:              (CourseFields.virtual_status, string_converter),
     CourseAttribute.URL:                        (CourseFields.url, string_converter),
     CourseAttribute.averageRating:              (CourseFields.rating, float_converter),
     CourseAttribute.averageInClassHours:        (CourseFields.in_class_hours, float_converter),
@@ -316,6 +318,7 @@ class Course(models.Model):
     enrollment_number = models.FloatField(default=0.0)
     related_subjects = models.CharField(null=True, max_length=250)
     schedule = models.TextField(null=True)
+    virtual_status = models.CharField(null=True, max_length=100)
 
     rating = models.FloatField(default=0.0)
     in_class_hours = models.FloatField(default=0.0)
@@ -376,6 +379,9 @@ class Course(models.Model):
             data[CourseFields.parent] = self.parent
         if self.children is not None and len(self.children) > 0:
             data[CourseFields.children] = self.children.split(",")
+
+        if self.virtual_status is not None and len(self.virtual_status) > 0:
+            data[CourseFields.virtual_status] = self.virtual_status
 
         if not full: return data
 

--- a/catalog_parse/utils/catalog_constants.py
+++ b/catalog_parse/utils/catalog_constants.py
@@ -111,6 +111,7 @@ class CourseAttribute:
     corequisites = "Coreqs"
     notes = "Notes"
     schedule = "Schedule"
+    virtualStatus = "Virtual Status"
     notOfferedYear = "Not Offered Year"
     hassRequirement = "Hass Attribute"
     GIR = "Gir Attribute"
@@ -170,6 +171,7 @@ ALL_ATTRIBUTES = [
     CourseAttribute.quarterInformation,
     CourseAttribute.instructors,
     CourseAttribute.schedule,
+    CourseAttribute.virtualStatus,
     CourseAttribute.URL,
     CourseAttribute.averageRating,
     CourseAttribute.averageInClassHours,
@@ -200,6 +202,7 @@ CONDENSED_ATTRIBUTES = [
     CourseAttribute.offeredSummer,
     CourseAttribute.quarterInformation,
     CourseAttribute.instructors,
+    CourseAttribute.virtualStatus,
     CourseAttribute.communicationRequirement,
     CourseAttribute.hassRequirement,
     CourseAttribute.GIR,

--- a/courseupdater/models.py
+++ b/courseupdater/models.py
@@ -15,6 +15,9 @@ class CatalogUpdate(models.Model):
     is_staged = models.BooleanField(default=False)
     is_started = models.BooleanField(default=False)
 
+    # Options for the parse
+    designate_virtual_status = models.BooleanField(default=False)
+
     def __str__(self):
         base = "Catalog update for {} on {}".format(self.semester, self.creation_date)
         if self.is_completed:
@@ -27,6 +30,11 @@ class CatalogUpdate(models.Model):
 
 class CatalogUpdateStartForm(forms.Form):
     semester = forms.CharField(label='Semester', max_length=30, widget=forms.TextInput(attrs={'class': 'input-field', 'placeholder': 'e.g. fall-2019'}))
+    designate_virtual_status = forms.BooleanField(label='Designate subject virtual status',
+                                                  widget=forms.CheckboxInput(attrs={'class':
+                                                                                    'filled-in'}),
+                                                  initial=False,
+                                                  required=False)
 
     def clean_semester(self):
         """

--- a/courseupdater/templates/courseupdater/start_update.html
+++ b/courseupdater/templates/courseupdater/start_update.html
@@ -15,6 +15,13 @@
       {{ form.semester }}
       <span class="red-text text-darken-4">{{ form.semester.errors }}</span>
       <br/>
+      <br/>
+      <label>
+        {{ form.designate_virtual_status }}
+        <span class="black-text">{{ form.designate_virtual_status.label }}</span>
+      </label>
+      <br/>
+      <br/>
       <button class="btn mbtn red waves-effect waves-light" type="submit" name="action">Start</button>
       {{ form.non_field_errors }}
     </form>

--- a/courseupdater/views.py
+++ b/courseupdater/views.py
@@ -160,7 +160,8 @@ def update_catalog(request):
         if request.method == 'POST':
             form = CatalogUpdateStartForm(request.POST)
             if form.is_valid():
-                update = CatalogUpdate(semester=form.cleaned_data['semester'])
+                update = CatalogUpdate(semester=form.cleaned_data['semester'],
+                                       designate_virtual_status=form.cleaned_data['designate_virtual_status'])
                 update.save()
                 return render(request, 'courseupdater/update_progress.html', {'update': update})
         else:

--- a/update_catalog.py
+++ b/update_catalog.py
@@ -130,7 +130,9 @@ if __name__ == '__main__':
             print("No equivalences file found - consider adding one (see catalog_parse/utils/parse_equivalences.py).")
             equivalences_path = None
 
-        cp.parse(out_path, evaluations_path, equivalences_path, progress_callback=update_progress)
+        cp.parse(out_path, evaluations_path, equivalences_path,
+                 progress_callback=update_progress,
+                 write_virtual_status=update.designate_virtual_status)
 
         consensus_path = os.path.join(settings.CATALOG_BASE_DIR, semester + "-new")
         if os.path.exists(consensus_path):


### PR DESCRIPTION
Adds a "Virtual Status" field to the course listing that indicates whether a course is offered virtually, in-person, or both. This information is directly inferred from the registrar site's class schedule, which marks online-only sections as "VIRTUAL" in place of a physical location.