### PR TITLE
Improved local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ db.sqlite3
 .ipynb_checkpoints
 */migrations/*
 static/**/*
+
+data/catalogs/**

--- a/common/templates/common/base.html
+++ b/common/templates/common/base.html
@@ -41,6 +41,7 @@
       <li><a class="red-text text-darken-3" href="/requirements/review/">Edit Requests</a></li>
       <li><a class="red-text text-darken-3" href="/courseupdater/update_catalog/">Catalog Update</a></li>
       <li><a class="red-text text-darken-3" href="/courseupdater/corrections/">Catalog Corrections</a></li>
+      <li><a class="red-text text-darken-3" href="/courseupdater/download_data/">Download Catalog Data</a></li>
     </ul>
     {% endif %}
 
@@ -80,6 +81,7 @@
       <li><a href="/requirements/review/">Edit Requests</a></li>
       <li><a href="/courseupdater/update_catalog/">Catalog Update</a></li>
       <li><a href="/courseupdater/corrections/">Catalog Corrections</a></li>
+      <li><a href="/courseupdater/download_data/">Download Catalog Data</a></li>
     </ul>
     {% endif %}
 

--- a/courseupdater/urls.py
+++ b/courseupdater/urls.py
@@ -15,4 +15,6 @@ urlpatterns = [
     url(r'corrections/edit/(?P<id>\d+)', views.edit_correction, name='edit_catalog_correction'),
     url(r'corrections/new', views.new_correction, name='new_catalog_correction'),
     url(r'corrections/', views.view_corrections, name='catalog_corrections'),
+
+    url(r'download_data/', views.download_catalog_data, name='download_data')
 ]

--- a/data/readme.md
+++ b/data/readme.md
@@ -1,0 +1,85 @@
+# FireRoad Catalog Data
+
+FireRoad's functionality depends on managing an up-to-date data source for both course catalogs and requirements. This data is expected to be located in the directory named in the settings file (`fireroad.settings` for local testing, `fireroad.settings_dev` for the dev server, and `fireroad.settings_prod` for the prod server). You can obtain an up-to-date copy of the data through the Django admin menu on either deployed service.
+
+The catalog data is structured this way (in addition to the database model) for ease of managing specific files corresponding to catalogs or requirements lists; also, the files are statically served for the mobile apps.
+
+## Structure
+
+The catalogs directory should be structured as follows:
+
+```
+- requirements
+   - major1.reql
+   - ...
+- sem-fall-2019
+   - 1.txt
+   - ...
+- sem-spring-2020
+   - 1.txt
+   - ...
+- ...
+- raw
+   - sem-spring-2020
+      - 1.txt
+      - ...
+   - ...
+- deltas
+   - requirements
+      - delta-1.txt
+      - ...
+   - sem-fall-2019
+      - delta-1.txt
+      - ...
+   - sem-spring-2020
+      - delta-1.txt
+      - ...
+```
+
+The top-level directories contain the data files for `requirements` and semesters (prefixed by `sem-`). The `raw` directory contains intermediate files generated during catalog parse operations (see below). The `deltas` directory contains a directory named for each of those top-level directories, which contains the delta files for each version of the catalog. 
+
+Each delta file is named `delta-[VERSION-NUMBER].txt` and formatted as follows (filenames are listed without extension):
+
+```
+[SEASON]#,#[YEAR]
+[VERSION NUMBER]
+[CHANGED FILENAME 1]
+[CHANGED FILENAME 2]
+...
+```
+
+## Update Scripts
+
+The course catalog update process is automated and can largely be managed through the web interface. However, because this is a singleton process that must occur outside a single server-client connection, it relies on the external script `update_catalog.py`, which is run as a cron job every few minutes on deployed servers. Similarly, the `update_db.py` script is scheduled to run daily during the early morning, to avoid performing database tasks during normal usage hours.
+
+You can run these scripts manually in the command line as well. First, set the `DJANGO_SETTINGS_MODULE` environment variable in your terminal:
+
+```
+export DJANGO_SETTINGS_MODULE="fireroad.settings"
+```
+
+Then, run the script as directed below.
+
+### Catalog Updates
+
+ On a local version, you can easily start this script manually by the command
+
+```
+python update_catalog.py [SEASON]-[YEAR]
+```
+
+where `[SEASON]-[YEAR]` specifies the current semester (e.g. `fall-2020`). Once this script is started, you can navigate to the catalog update page in the UI to watch the progress and review the results. When it is finished, you will need to click Deploy Update. Finally, run the database update script:
+
+```
+python update_db.py
+```
+
+Note that each of these scripts may take several minutes to run.
+
+### Requirements Updates
+
+Requirements list updating follows a similar process to the course catalog, except that updates are entered manually instead of scraped. Therefore, you can edit the requirements lists directly in the Requirements Editor, deploy them, and then run the database update script:
+
+```
+python update_db.py
+```

--- a/data/readme.md
+++ b/data/readme.md
@@ -78,7 +78,7 @@ Note that each of these scripts may take several minutes to run.
 
 ### Requirements Updates
 
-Requirements list updating follows a similar process to the course catalog, except that updates are entered manually instead of scraped. Therefore, you can edit the requirements lists directly in the Requirements Editor, deploy them, and then run the database update script:
+Requirements list updating follows a similar process to the course catalog, except that updates are entered manually instead of scraped. Therefore, you can create and edit the requirements lists directly in the Requirements Editor, deploy them, and then run the database update script:
 
 ```
 python update_db.py

--- a/fireroad/settings.py
+++ b/fireroad/settings.py
@@ -10,7 +10,8 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-CATALOG_BASE_DIR = ""
+# Unzip the catalog data into the data directory
+CATALOG_BASE_DIR = "data/catalogs"
 
 # Use the Django default login page for local debugging
 LOGIN_URL = "/admin/login"

--- a/fireroad/settings.py
+++ b/fireroad/settings.py
@@ -53,7 +53,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
-    #'django.middleware.security.SecurityMiddleware',
+    # Cors middleware should only be on local development (not settings_dev or settings_prod)
+    'middleware.cors.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/fireroad/settings_dev.py
+++ b/fireroad/settings_dev.py
@@ -33,4 +33,12 @@ DATABASES = {
     }
 }
 
-
+MIDDLEWARE_CLASSES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'analytics.request_counter.RequestCounterMiddleware'
+]

--- a/fireroad/settings_prod.py
+++ b/fireroad/settings_prod.py
@@ -33,4 +33,12 @@ DATABASES = {
     }
 }
 
-
+MIDDLEWARE_CLASSES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'analytics.request_counter.RequestCounterMiddleware'
+]

--- a/middleware/cors.py
+++ b/middleware/cors.py
@@ -1,0 +1,10 @@
+"""
+Small middleware to allow cross-origin resource sharing. Should only be enabled
+in a local development environment.
+"""
+
+class CorsMiddleware(object):
+    def process_response(self, req, resp):
+        resp["Access-Control-Allow-Origin"] = "*"
+        resp["Access-Control-Allow-Headers"] = "*"
+        return resp

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,16 @@ To set up a catalog (including courses and requirements lists):
 
 This script will prompt you to download a copy of the course catalog from the [prod site](https://fireroad.mit.edu/courseupdater/download_data) if you have not already. Otherwise, you can run the catalog setup script without pre-initialized catalogs, then run the scraper yourself following the instructions in `data/readme.md`.
 
+## Running the Server
+
+To run the server (with the conda environment activated), use
+
+```
+python manage.py runserver
+```
+
+By default, the server runs on port 8000. You can specify a different port by simply adding the port number after the `runserver` command. (The `manage.py` script is [provided by Django](https://docs.djangoproject.com/en/1.11/ref/django-admin/) and provides other useful commands such as migrating the database, collecting static files, and opening an interactive shell.)
+
 ## Database Settings
 
 Note that the project contains three Django settings modules: `fireroad/settings.py` (local development), `fireroad/settings_dev.py` (dev server), and `fireroad_settings_prod.py` (prod server). When making changes to the settings, please make sure to change the file appropriate to the environment on which you want the changes to take effect (and note that the latter two import the base `settings.py` file). In order to specify which settings module should be used, you will need to set the `DJANGO_SETTINGS_MODULE` environment variable to `fireroad.settings{VARIANT}`, and change the default value specified in `fireroad/wsgi.py` if deploying with WSGI.

--- a/readme.md
+++ b/readme.md
@@ -8,15 +8,25 @@ Follow these instructions to set up and run your own instance of the FireRoad se
 
 ```
 conda create -n fireroad python=2.7
-source activate fireroad
+conda activate fireroad
 ```
 
 Then, enter the repo directory and run the setup script, which will install any necessary packages and set up the database.
 
 ```
-$ cd fireroad-server
-$ ./setup.sh
+cd fireroad-server
+./setup.sh
 ```
+
+To set up a catalog (including courses and requirements lists):
+
+```
+./setup_catalog.sh
+```
+
+This script will prompt you to download a copy of the course catalog from the [prod site](https://fireroad.mit.edu/courseupdater/download_data) if you have not already. Otherwise, you can run the catalog setup script without pre-initialized catalogs, then run the scraper yourself following the instructions in `data/readme.md`.
+
+## Database Settings
 
 Note that the project contains three Django settings modules: `fireroad/settings.py` (local development), `fireroad/settings_dev.py` (dev server), and `fireroad_settings_prod.py` (prod server). When making changes to the settings, please make sure to change the file appropriate to the environment on which you want the changes to take effect (and note that the latter two import the base `settings.py` file). In order to specify which settings module should be used, you will need to set the `DJANGO_SETTINGS_MODULE` environment variable to `fireroad.settings{VARIANT}`, and change the default value specified in `fireroad/wsgi.py` if deploying with WSGI.
 
@@ -25,6 +35,6 @@ Depending on your settings, there may be additional files that you can add to en
 * To use a MySQL database, add a `fireroad/dbcreds.py` file that specifies the necessary authentication info as Python variables `dbname`, `username`, `password`, and `host`.
 * To enable sending emails to admins for unresolved edit requests, etc., create an email address with two-factor authentication disabled (gmail works well). Then add a `fireroad/email_creds.py` file that specifies authentication info as a comma-delimited string with three components: the email server (e.g. `smtp.gmail.com`), the email address, and the password for the email account.
 
-### API Endpoints
+## API Endpoints
 
 The FireRoad API is fully documented at [fireroad.mit.edu/reference](https://fireroad.mit.edu/reference) (dev version at [fireroad-dev.mit.edu/reference](https://fireroad-dev.mit.edu/reference)). When submitting PRs that modify the behavior of these endpoints or add new ones, please update the docs in `common/templates/docs` accordingly.

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Installing dependencies
-pip install django==1.11.15 pandas nltk lxml scipy scikit-learn requests pyjwt==1.6.4
+pip install django==1.11.15 pandas nltk==3.4 lxml scipy scikit-learn requests pyjwt==1.6.4
 echo
 echo
 

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ if [[ $keepbackend == "y" ]]; then
     echo "Migrating to database $NAME..."
 
     # Migrations
-    python manage.py makemigrations common catalog courseupdater sync recommend requirements
+    python manage.py makemigrations analytics common catalog courseupdater sync recommend requirements
     read -p "Ready to migrate? (y/n) " ready
     if [[ $ready != "y" ]]; then
       echo "Use the following command to migrate the database when ready:"

--- a/setup_catalog.sh
+++ b/setup_catalog.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script handles setting up the catalog for local development.
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+CATALOG_DIR=$( python -c "from fireroad.settings import CATALOG_BASE_DIR; print(CATALOG_BASE_DIR)" )
+if [ ! -d $CATALOG_DIR ]; then 
+  echo "It looks like the course catalog directory is currently empty. You can download a copy (https://fireroad.mit.edu/courseupdater/download_data) and unzip it in the data directory."
+  echo
+  echo "Alternatively, you can begin without initial data using the instructions in data/readme.md."
+  echo
+  echo 
+
+  read -p "Would you like to begin without initial data? (y/n) " ready
+  if [[ $ready != "y" ]]; then
+    echo "Run this script again after downloading and placing the catalog data."
+    exit 0
+  fi
+
+  # Set up directories
+  mkdir -p $CATALOG_DIR
+  mkdir -p $CATALOG_DIR/raw
+  mkdir -p $CATALOG_DIR/requirements
+  mkdir -p $CATALOG_DIR/deltas
+  mkdir -p $CATALOG_DIR/deltas/requirements
+
+  echo "Done creating directories at $CATALOG_DIR. Follow the instructions in data/readme.md to run the catalog parser and create requirements lists."
+fi
+
+# Set location of settings file
+export DJANGO_SETTINGS_MODULE="fireroad.settings"
+echo -e "${GREEN}Running database update script...${NC}"
+python update_db.py

--- a/setup_catalog.sh
+++ b/setup_catalog.sh
@@ -27,6 +27,7 @@ if [ ! -d $CATALOG_DIR ]; then
   mkdir -p $CATALOG_DIR/deltas/requirements
 
   echo "Done creating directories at $CATALOG_DIR. Follow the instructions in data/readme.md to run the catalog parser and create requirements lists."
+  exit 0
 fi
 
 # Set location of settings file


### PR DESCRIPTION
Adds clearer instructions and automation for how to set up a FireRoad instance locally.

* Improved instructions in the main `readme.md`, and a new `data/readme.md` file describing catalog data structure
* Catalogs are now stored in `data/catalogs` by default instead of making you choose a location
* New `courseupdater/download_data` endpoint that returns a zipped catalog directory, which can be dropped into the `data` directory for easy setup
* New `setup_catalog.sh` script which prompts you to download the data or creates an empty initialized catalog directory for you
* Add CORS middleware for testing other frontend services locally