### PR TITLE
Remove approved_users field from APIClient admin

### DIFF
--- a/common/admin.py
+++ b/common/admin.py
@@ -3,6 +3,11 @@ from django.contrib import admin
 # Register your models here.
 from .models import *
 
+# The approved_users field creates some issues when trying to update APIClients,
+# so just remove it entirely
+class APIClientAdmin(admin.ModelAdmin):
+    exclude = ('approved_users',)
+
 admin.site.register(Student)
 admin.site.register(RedirectURL)
-admin.site.register(APIClient)
+admin.site.register(APIClient, APIClientAdmin)


### PR DESCRIPTION
Solves the 400 bad request error when trying to edit APIClients. I think this is a bug in Django relating to the many-to-many field editor for the `approved_users` field, so removing that field is an effective workaround.