### PR TITLE
Add support for EECS renumbering

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -288,8 +288,8 @@ class Course(models.Model):
     either_prereq_or_coreq = models.BooleanField(default=False)
 
     # EECS subject renumbering
-    old_id = models.TextField(null=True)
-    new_id = models.TextField(null=True)
+    old_id = models.CharField(max_length=20, null=True)
+    new_id = models.CharField(max_length=20, null=True)
 
     gir_attribute = models.CharField(max_length=20, null=True)
     communication_requirement = models.CharField(max_length=30, null=True)

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -388,6 +388,9 @@ class Course(models.Model):
         if self.virtual_status is not None and len(self.virtual_status) > 0:
             data[CourseFields.virtual_status] = self.virtual_status
 
+        if self.old_id is not None and len(self.old_id) > 0:
+            data[CourseFields.old_id] = self.old_id
+
         if not full: return data
 
         data[CourseFields.lecture_units] = self.lecture_units

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -112,7 +112,6 @@ class CourseFields:
     enrollment_number = "enrollment_number"
     either_prereq_or_coreq = "either_prereq_or_coreq"
     old_id = "old_id"
-    new_id = "new_id"
     public = "public"
     creator = "creator"
     custom_color = "custom_color"
@@ -180,7 +179,6 @@ CSV_HEADERS = {
     CourseAttribute.enrollment:                 (CourseFields.enrollment_number, float_converter),
     CourseAttribute.eitherPrereqOrCoreq:        (CourseFields.either_prereq_or_coreq, bool_converter),
     CourseAttribute.oldID:                      (CourseFields.old_id, string_converter),
-    CourseAttribute.newID:                      (CourseFields.new_id, string_converter),
     CourseAttribute.sourceSemester:             (CourseFields.source_semester, string_converter),
     CourseAttribute.isHistorical:               (CourseFields.is_historical, bool_converter),
     CourseAttribute.parent:                     (CourseFields.parent, string_converter),
@@ -289,7 +287,6 @@ class Course(models.Model):
 
     # EECS subject renumbering
     old_id = models.CharField(max_length=20, null=True)
-    new_id = models.CharField(max_length=20, null=True)
 
     gir_attribute = models.CharField(max_length=20, null=True)
     communication_requirement = models.CharField(max_length=30, null=True)

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -111,6 +111,8 @@ class CourseFields:
     enrollment_number = "enrollment_number"
     enrollment_number = "enrollment_number"
     either_prereq_or_coreq = "either_prereq_or_coreq"
+    old_id = "old_id"
+    new_id = "new_id"
     public = "public"
     creator = "creator"
     custom_color = "custom_color"
@@ -177,6 +179,8 @@ CSV_HEADERS = {
     CourseAttribute.averageOutOfClassHours:     (CourseFields.out_of_class_hours, float_converter),
     CourseAttribute.enrollment:                 (CourseFields.enrollment_number, float_converter),
     CourseAttribute.eitherPrereqOrCoreq:        (CourseFields.either_prereq_or_coreq, bool_converter),
+    CourseAttribute.oldID:                      (CourseFields.old_id, string_converter),
+    CourseAttribute.newID:                      (CourseFields.new_id, string_converter),
     CourseAttribute.sourceSemester:             (CourseFields.source_semester, string_converter),
     CourseAttribute.isHistorical:               (CourseFields.is_historical, bool_converter),
     CourseAttribute.parent:                     (CourseFields.parent, string_converter),
@@ -282,6 +286,10 @@ class Course(models.Model):
     prerequisites = models.TextField(null=True)
     corequisites = models.TextField(null=True)
     either_prereq_or_coreq = models.BooleanField(default=False)
+
+    # EECS subject renumbering
+    old_id = models.TextField(null=True)
+    new_id = models.TextField(null=True)
 
     gir_attribute = models.CharField(max_length=20, null=True)
     communication_requirement = models.CharField(max_length=30, null=True)

--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -10,7 +10,6 @@ import requests
 import re
 import sys
 import os
-import json
 
 from .utils import *
 
@@ -52,10 +51,6 @@ COURSE_NUMBERS = [
 ]
 
 ALPHABET = "abcdefghijklmnopqrstuvwxyz"
-
-RENUMBERING_URL = "https://eecsis.mit.edu/numbering.html"
-
-RENUMBERING_DATA = None
 
 # Stores the HTML of the last page retrieved
 LAST_PAGE_HTML = None
@@ -184,29 +179,6 @@ def extract_course_properties(elements):
 
     return info_items
 
-def load_renumbering_data():
-    """
-    Downloads the EECS subject renumbering data, converts it to a Python
-    object, and stores it in RENUMBERING_DATA unless this has already been
-    done.
-    """
-    global RENUMBERING_DATA
-
-    if RENUMBERING_DATA is not None:
-        return
-
-    page = requests.get(RENUMBERING_URL)
-    assert page.status_code == 200
-
-    content = page.content
-    _, content = content.split("generatePage([")
-    content, _ = content.split("])")
-    content = "[" + content + "]"
-
-    RENUMBERING_DATA = json.loads(content)
-    assert RENUMBERING_DATA is not None
-    return
-
 ### Information Item Processing
 
 def subject_title_regex(subject_id):
@@ -259,6 +231,11 @@ def process_info_item(item, attributes, write_virtual_status=False):
             attributes[CourseAttribute.subjectID] = match.group(0).strip()
         end = match.end(0)
         attributes[CourseAttribute.title] = item[end:].replace(CatalogConstants.joint_class, "").strip()
+        def_not_desc = True
+
+    # Old subject ID
+    elif re.match(r'\(\d{1,2}.[A-Z0-9]{1,4}\)$', item):
+        attributes[CourseAttribute.oldID] = item[1:-1]
         def_not_desc = True
 
     # Subject level
@@ -482,17 +459,6 @@ def courses_from_dept_code(dept_code, **options):
         # For example, 6.260, 6.261 Advanced Topics in Communications
         if len(autofill_ids) > 0:
             autofill_ids = []
-
-    # Add old and new IDs for EECS renumbering
-    if dept_code[:-1] == "6":
-        load_renumbering_data()
-        for course in courses:
-            id = course[CourseAttribute.subjectID]
-            for item in RENUMBERING_DATA:
-                if item["newnum"] == id or item["oldnum"] == id:
-                    course[CourseAttribute.oldID] = item["oldnum"]
-                    course[CourseAttribute.subjectID] = item["newnum"]
-                    break
 
     return courses
 

--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -491,7 +491,7 @@ def courses_from_dept_code(dept_code, **options):
             for item in RENUMBERING_DATA:
                 if item["newnum"] == id or item["oldnum"] == id:
                     course[CourseAttribute.oldID] = item["oldnum"]
-                    course[CourseAttribute.newID] = item["newnum"]
+                    course[CourseAttribute.subjectID] = item["newnum"]
                     break
 
     return courses

--- a/catalog_parse/consensus_catalog.py
+++ b/catalog_parse/consensus_catalog.py
@@ -77,8 +77,11 @@ def build_consensus(base_path, out_path, corrections=None):
 
         # Get set of old subject IDs that have been renumbered in future
         # semesters
-        old_ids = set().union(*(data.loc[:, CourseAttribute.oldID].dropna()
-                                for semester, data in semester_data[:i]))
+        old_ids = set().union(*(
+            data.loc[:, CourseAttribute.oldID].dropna()
+            if CourseAttribute.oldID in data.columns else []
+            for semester, data in semester_data[:i]
+        ))
         data = data.loc[~data[CourseAttribute.subjectID].isin(old_ids)]
 
         if consensus is None:

--- a/catalog_parse/consensus_catalog.py
+++ b/catalog_parse/consensus_catalog.py
@@ -68,16 +68,17 @@ def build_consensus(base_path, out_path, corrections=None):
         print("No raw semester data found.")
         return
 
-    # Get set of old subject IDs that have been renumbered
-    old_ids = set().union(*(data.loc[:, CourseAttribute.oldID].dropna()
-                            for semester, data in semester_data))
-
     # Build consensus by iterating from new to old
     consensus = None
     last_size = 0
     for i, (semester, data) in enumerate(semester_data):
         data[CourseAttribute.sourceSemester] = semester[semester.find("-") + 1:]
         data[CourseAttribute.isHistorical] = "Y" if (i != 0) else ""
+
+        # Get set of old subject IDs that have been renumbered in future
+        # semesters
+        old_ids = set().union(*(data.loc[:, CourseAttribute.oldID].dropna()
+                                for semester, data in semester_data[:i]))
         data = data.loc[~data[CourseAttribute.subjectID].isin(old_ids)]
 
         if consensus is None:

--- a/catalog_parse/utils/catalog_constants.py
+++ b/catalog_parse/utils/catalog_constants.py
@@ -124,7 +124,7 @@ class CourseAttribute:
     subjectLevel = "Subject Level"
     eitherPrereqOrCoreq = "Prereq or Coreq"
 
-    # EECS renumbering (fall 2022)
+    # Old subject ID (renumbering)
     oldID = "Old Subject Id"
 
     # Evaluation fields

--- a/catalog_parse/utils/catalog_constants.py
+++ b/catalog_parse/utils/catalog_constants.py
@@ -124,6 +124,10 @@ class CourseAttribute:
     subjectLevel = "Subject Level"
     eitherPrereqOrCoreq = "Prereq or Coreq"
 
+    # Renumbering fields
+    oldID = "Old Subject Id"
+    newID = "New Subject Id"
+
     # Evaluation fields
     averageRating = "Rating"
     averageInClassHours = "In-Class Hours"
@@ -159,6 +163,8 @@ ALL_ATTRIBUTES = [
     CourseAttribute.oldPrerequisites,
     CourseAttribute.oldCorequisites,
     CourseAttribute.eitherPrereqOrCoreq,
+    CourseAttribute.oldID,
+    CourseAttribute.newID,
     CourseAttribute.description,
     CourseAttribute.jointSubjects,
     CourseAttribute.meetsWithSubjects,
@@ -192,6 +198,8 @@ CONDENSED_ATTRIBUTES = [
     CourseAttribute.oldPrerequisites,
     CourseAttribute.oldCorequisites,
     CourseAttribute.eitherPrereqOrCoreq,
+    CourseAttribute.oldID,
+    CourseAttribute.newID,
     CourseAttribute.jointSubjects,
     CourseAttribute.equivalentSubjects,
     CourseAttribute.meetsWithSubjects,

--- a/catalog_parse/utils/catalog_constants.py
+++ b/catalog_parse/utils/catalog_constants.py
@@ -124,9 +124,8 @@ class CourseAttribute:
     subjectLevel = "Subject Level"
     eitherPrereqOrCoreq = "Prereq or Coreq"
 
-    # Renumbering fields
+    # EECS renumbering (fall 2022)
     oldID = "Old Subject Id"
-    newID = "New Subject Id"
 
     # Evaluation fields
     averageRating = "Rating"
@@ -164,7 +163,6 @@ ALL_ATTRIBUTES = [
     CourseAttribute.oldCorequisites,
     CourseAttribute.eitherPrereqOrCoreq,
     CourseAttribute.oldID,
-    CourseAttribute.newID,
     CourseAttribute.description,
     CourseAttribute.jointSubjects,
     CourseAttribute.meetsWithSubjects,
@@ -199,7 +197,6 @@ CONDENSED_ATTRIBUTES = [
     CourseAttribute.oldCorequisites,
     CourseAttribute.eitherPrereqOrCoreq,
     CourseAttribute.oldID,
-    CourseAttribute.newID,
     CourseAttribute.jointSubjects,
     CourseAttribute.equivalentSubjects,
     CourseAttribute.meetsWithSubjects,


### PR DESCRIPTION
Fixes #30. I can confirm that these changes generate the "Subject Old Id" and "Subject New Id" columns properly in the output of the catalog parser, but I could not test the API endpoint because I had trouble getting the database set up properly. (The deltas were not being generated correctly; I could look into this further if necessary.)