### PR TITLE
Multiple schedules for subjects in multiple semesters

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -101,8 +101,14 @@ class CourseFields:
     has_final = "has_final"
     not_offered_year = "not_offered_year"
     quarter_information = "quarter_information"
+    quarter_information_fall = "quarter_information_fall"
+    quarter_information_IAP = "quarter_information_IAP"
+    quarter_information_spring = "quarter_information_spring"
     related_subjects = "related_subjects"
     schedule = "schedule"
+    schedule_fall = "schedule_fall"
+    schedule_IAP = "schedule_IAP"
+    schedule_spring = "schedule_spring"
     virtual_status = "virtual_status"
     url = "url"
     rating = "rating"
@@ -170,7 +176,13 @@ CSV_HEADERS = {
     CourseAttribute.hasFinal:                   (CourseFields.has_final, bool_converter),
     CourseAttribute.notOfferedYear:             (CourseFields.not_offered_year, string_converter),
     CourseAttribute.quarterInformation:         (CourseFields.quarter_information, string_converter),
+    CourseAttribute.quarterInformationFall:     (CourseFields.quarter_information_fall, string_converter),
+    CourseAttribute.quarterInformationIAP:      (CourseFields.quarter_information_IAP, string_converter),
+    CourseAttribute.quarterInformationSpring:   (CourseFields.quarter_information_spring, string_converter),
     CourseAttribute.schedule:                   (CourseFields.schedule, string_converter),
+    CourseAttribute.scheduleFall:               (CourseFields.schedule_fall, string_converter),
+    CourseAttribute.scheduleIAP:                (CourseFields.schedule_IAP, string_converter),
+    CourseAttribute.scheduleSpring:             (CourseFields.schedule_spring, string_converter),
     CourseAttribute.virtualStatus:              (CourseFields.virtual_status, string_converter),
     CourseAttribute.URL:                        (CourseFields.url, string_converter),
     CourseAttribute.averageRating:              (CourseFields.rating, float_converter),
@@ -317,12 +329,20 @@ class Course(models.Model):
     not_offered_year = models.CharField(max_length=15, null=True)
 
     quarter_information = models.CharField(max_length=30, null=True)
+    quarter_information_fall = models.CharField(max_length=30, null=True)
+    quarter_information_IAP = models.CharField(max_length=30, null=True)
+    quarter_information_spring = models.CharField(max_length=30, null=True)
 
     url = models.CharField(max_length=75, null=True)
 
     enrollment_number = models.FloatField(default=0.0)
     related_subjects = models.CharField(null=True, max_length=250)
+
     schedule = models.TextField(null=True)
+    schedule_fall = models.TextField(null=True)
+    schedule_IAP = models.TextField(null=True)
+    schedule_spring = models.TextField(null=True)
+
     virtual_status = models.CharField(null=True, max_length=100)
 
     rating = models.FloatField(default=0.0)
@@ -368,6 +388,13 @@ class Course(models.Model):
 
         if self.quarter_information is not None and len(self.quarter_information) > 0:
             data[CourseFields.quarter_information] = self.quarter_information
+        if self.quarter_information_fall is not None and len(self.quarter_information_fall) > 0:
+            data[CourseFields.quarter_information_fall] = self.quarter_information_fall
+        if self.quarter_information_IAP is not None and len(self.quarter_information_IAP) > 0:
+            data[CourseFields.quarter_information_IAP] = self.quarter_information_IAP
+        if self.quarter_information_spring is not None and len(self.quarter_information_spring) > 0:
+            data[CourseFields.quarter_information_spring] = self.quarter_information_spring
+
         if self.not_offered_year is not None and len(self.not_offered_year) > 0:
             data[CourseFields.not_offered_year] = self.not_offered_year
 
@@ -410,8 +437,16 @@ class Course(models.Model):
             data[CourseFields.corequisites] = self.corequisites
         if self.either_prereq_or_coreq:
             data[CourseFields.either_prereq_or_coreq] = self.either_prereq_or_coreq
+
         if self.schedule is not None and len(self.schedule) > 0:
             data[CourseFields.schedule] = self.schedule
+        if self.schedule_fall is not None and len(self.schedule_fall) > 0:
+            data[CourseFields.schedule_fall] = self.schedule_fall
+        if self.schedule_IAP is not None and len(self.schedule_IAP) > 0:
+            data[CourseFields.schedule_IAP] = self.schedule_IAP
+        if self.schedule_spring is not None and len(self.schedule_spring) > 0:
+            data[CourseFields.schedule_spring] = self.schedule_spring
+
         if self.url is not None and len(self.url) > 0:
             data[CourseFields.url] = self.url
         if self.related_subjects is not None and len(self.related_subjects) > 0:

--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -215,11 +215,27 @@ def process_info_item(item, attributes, write_virtual_status=False):
             attributes[CourseAttribute.hasFinal] = True
             trimmed_item = trimmed_item.replace(CatalogConstants.final_flag, "")
 
-        sched, quarter_info, virtual_status = parse_schedule(trimmed_item.strip().replace("\n", ""))
+        sched, quarter_info, sem, virtual_status = parse_schedule(trimmed_item.strip().replace("\n", ""))
+
+        sched_attrs = [CourseAttribute.schedule]
+        quarter_info_attrs = [CourseAttribute.quarterInformation]
+
+        if sem == "Fall":
+            sched_attrs.append(CourseAttribute.scheduleFall)
+            quarter_info_attrs.append(CourseAttribute.quarterInformationFall)
+        elif sem == "IAP":
+            sched_attrs.append(CourseAttribute.scheduleIAP)
+            quarter_info_attrs.append(CourseAttribute.quarterInformationIAP)
+        elif sem == "Spring":
+            sched_attrs.append(CourseAttribute.scheduleSpring)
+            quarter_info_attrs.append(CourseAttribute.quarterInformationSpring)
+
         if len(sched) > 0:
-            attributes[CourseAttribute.schedule] = sched
+            for attr in sched_attrs:
+                attributes[attr] = sched
         if len(quarter_info) > 0:
-            attributes[CourseAttribute.quarterInformation] = quarter_info
+            for attr in quarter_info_attrs:
+                attributes[attr] = quarter_info
         if write_virtual_status:
             attributes[CourseAttribute.virtualStatus] = virtual_status
         def_not_desc = True
@@ -451,8 +467,12 @@ def courses_from_dept_code(dept_code, **options):
                 courses.append(copied_course)
         else:
             # Use only the first item in the schedule dictionary
-            if CourseAttribute.schedule in attribs:
-                attribs[CourseAttribute.schedule] = list(attribs[CourseAttribute.schedule].values())[0]
+            for attrib in [CourseAttribute.schedule,
+                           CourseAttribute.scheduleFall,
+                           CourseAttribute.scheduleIAP,
+                           CourseAttribute.scheduleSpring]:
+                if attrib in attribs:
+                    attribs[attrib] = list(attribs[attrib].values())[0]
             courses.append(attribs)
 
         # Autofill regions that were empty with the subsequent course information

--- a/catalog_parse/utils/catalog_constants.py
+++ b/catalog_parse/utils/catalog_constants.py
@@ -111,6 +111,9 @@ class CourseAttribute:
     corequisites = "Coreqs"
     notes = "Notes"
     schedule = "Schedule"
+    scheduleFall = "Schedule Fall"
+    scheduleIAP = "Schedule Iap"
+    scheduleSpring = "Schedule Spring"
     virtualStatus = "Virtual Status"
     notOfferedYear = "Not Offered Year"
     hassRequirement = "Hass Attribute"
@@ -121,6 +124,9 @@ class CourseAttribute:
     equivalentSubjects = "Equivalent Subjects"
     URL = "URL"
     quarterInformation = "Quarter Information"
+    quarterInformationFall = "Quarter Information Fall"
+    quarterInformationIAP = "Quarter Information Iap"
+    quarterInformationSpring = "Quarter Information Spring"
     subjectLevel = "Subject Level"
     eitherPrereqOrCoreq = "Prereq or Coreq"
 
@@ -173,8 +179,14 @@ ALL_ATTRIBUTES = [
     CourseAttribute.offeredSpring,
     CourseAttribute.offeredSummer,
     CourseAttribute.quarterInformation,
+    CourseAttribute.quarterInformationFall,
+    CourseAttribute.quarterInformationIAP,
+    CourseAttribute.quarterInformationSpring,
     CourseAttribute.instructors,
     CourseAttribute.schedule,
+    CourseAttribute.scheduleFall,
+    CourseAttribute.scheduleIAP,
+    CourseAttribute.scheduleSpring,
     CourseAttribute.virtualStatus,
     CourseAttribute.URL,
     CourseAttribute.averageRating,
@@ -206,6 +218,9 @@ CONDENSED_ATTRIBUTES = [
     CourseAttribute.offeredSpring,
     CourseAttribute.offeredSummer,
     CourseAttribute.quarterInformation,
+    CourseAttribute.quarterInformationFall,
+    CourseAttribute.quarterInformationIAP,
+    CourseAttribute.quarterInformationSpring,
     CourseAttribute.instructors,
     CourseAttribute.virtualStatus,
     CourseAttribute.communicationRequirement,


### PR DESCRIPTION
Closes #36. Add new attributes `scheduleFall`, `scheduleIAP`, and `scheduleSpring`, and store the fall, IAP, and/or spring schedules of a subject here if the subject is offered and has schedules available in more than one semester.

In the case of such subjects, the schedule attribute is kept and populated with one of these schedules (for backwards compatibility), but the specific semester that is chosen is undefined. (Client code should check for the presence of `scheduleFall`/`scheduleIAP`/`scheduleSpring` -- depending on the semester -- and prefer the value of that attribute to that of the `schedule` attribute).