### PR TITLE
Fix schedule parsing for multi-subject entries

### DIFF
--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -232,7 +232,10 @@ def process_info_item(item, attributes, write_virtual_status=False):
 
         if len(sched) > 0:
             for attr in sched_attrs:
-                attributes[attr] = sched
+                if attr in attributes:
+                    attributes[attr].update(sched)
+                else:
+                    attributes[attr] = sched
         if len(quarter_info) > 0:
             for attr in quarter_info_attrs:
                 attributes[attr] = quarter_info


### PR DESCRIPTION
Fixes #48. When an entry has multiple subjects (e.g., 6.S963-6.S967), make sure that schedules from all subjects are included.