### PR TITLE
Sync names

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -108,6 +108,7 @@ def login_touchstone(request):
         # Only set the current semester if there's a real new value
         if request.GET.get('sem', '') and int(request.GET['sem']) != 0:
             student.current_semester = request.GET['sem']
+        student.name = student_name
         if student.user is None:
             user = make_new_user()
             user.save()

--- a/common/views.py
+++ b/common/views.py
@@ -39,6 +39,7 @@ def login_oauth(request):
     # Save the user's profile, check if there are any other accounts
     email = result.get(u'email', None)
     sub = result.get(u'sub', None)
+    student_name = result.get(u'name', 'Anonymous')
     if sub is None:
         return login_error_response(request, 'Please try again and allow FireRoad to access your OpenID information.')
 
@@ -50,13 +51,14 @@ def login_oauth(request):
 
         if email is None:
             email = "user{}@fireroad.mit.edu".format(user.username)
-        student = Student(user=user, unique_id=sub, academic_id=email, name=result.get(u'name', 'Anonymous'))
+        student = Student(user=user, unique_id=sub, academic_id=email, name=student_name)
         student.current_semester = info.get('sem', '0')
         student.save()
     else:
         # Only set the current semester if there's a real new value
         if len(info.get('sem', '')) > 0 and int(info['sem']) != 0:
             student.current_semester = info['sem']
+        student.name = student_name
         if student.user is None:
             user = make_new_user()
             user.save()


### PR DESCRIPTION
Per a user's feedback email, instead of setting the student's name only once when the user first logs in, update it each time we handle an OAuth login. (I'm not 100% sure this will work as I can't remember if the student name is always sent by Touchstone, but should be good to test out.)