### PR TITLE
Fix multiple semester subject schedule aliasing

### DIFF
--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -236,7 +236,7 @@ def process_info_item(item, attributes, write_virtual_status=False):
         if len(sched) > 0:
             for attr in sched_attrs:
                 if attr in attributes:
-                    attributes[attr].update(sched.copy())
+                    attributes[attr].update(sched)
                 else:
                     attributes[attr] = sched.copy()
         if len(quarter_info) > 0:

--- a/catalog_parse/catalog_parser.py
+++ b/catalog_parse/catalog_parser.py
@@ -236,9 +236,9 @@ def process_info_item(item, attributes, write_virtual_status=False):
         if len(sched) > 0:
             for attr in sched_attrs:
                 if attr in attributes:
-                    attributes[attr].update(sched)
+                    attributes[attr].update(sched.copy())
                 else:
-                    attributes[attr] = sched
+                    attributes[attr] = sched.copy()
         if len(quarter_info) > 0:
             for attr in quarter_info_attrs:
                 attributes[attr] = quarter_info


### PR DESCRIPTION
Bug fix: classes in both IAP and Fall/Spring no longer wrongly show the same schedule for both IAP and Fall/Spring
Issue was that the "sched" dictionary was being aliased, so just changed it do sched.copy()
fixes #56 
----------------------------------------------------------------
(sidenote):
not sure why that if-else block is necessary since it seemed to do the same as just doing:
    attributes[attr] = sched.copy()
since sched is a dictionary with only key as '' (empty string). e.g. for 21G.401 IAP/spring 2025:
    sched = {'': 'Lecture,16-654/MTRF/0/9,16-654/MTRF/0/12'}
    attributes[Schedule] = {'': 'Lecture,16-654/MTRF/0/9,16-654/MTRF/0/12'}
    attributes[Schedule IAP] = {'': 'Lecture,16-676/MTWRF/0/10-1'}
    attributes[Schedule Spring] = {'': 'Lecture,16-654/MTRF/0/9,16-654/MTRF/0/12'}
unless the attributes[Schedule] dict was intended to contain multiple keys (like both IAP and Spring schedules)?